### PR TITLE
Feature/Fix URL and use TXT credits

### DIFF
--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -377,10 +377,12 @@ $(document).ready(function() {
     const bodyTypeName = getBodyTypeName();
 
     sheetCredits = [creditColumns];
+    var baseUrl = window.location.href.split("/").slice(0, -1).join("/"); // get url until last '/'
+
     itemsMeta = {"bodyTypeName":bodyTypeName,
                  "url":window.location.href,
-                 "spritesheets":window.location.origin+"/spritesheets/",
-                 "version":1,
+                 "spritesheets":baseUrl+"/spritesheets/",   // <- holds base URL to spritesheets (used to download them)
+                 "version":1,                               // <- to track future compatibilty breaking changes
                  "datetime": (new Date().toLocaleString()),
                  "credits":[]}
 

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -384,7 +384,7 @@ $(document).ready(function() {
                  "spritesheets":baseUrl+"/spritesheets/",   // <- holds base URL to spritesheets (used to download them)
                  "version":1,                               // <- to track future compatibilty breaking changes
                  "datetime": (new Date().toLocaleString()),
-                 "credits":[]}
+                 "credits":""}
 
     zPosition = 0;
     $("input[type=radio]:checked").each(function(index) {
@@ -407,13 +407,14 @@ $(document).ready(function() {
             itemToDraw.variant = variant
             addCreditFor(fileName);
             itemsToDraw.push(itemToDraw);
-            itemsMeta["credits"].push(getCreditFor(fileName))
           }
         } else {
           break;
         }
       }
     });
+    itemsMeta["credits"] = sheetCreditsToTxt();
+
     if (images["uploaded"] != null) {
       const itemToDraw = {};
       itemToDraw.fileName = "uploaded";


### PR DESCRIPTION
window.location.origin returns the host only, e.g.
`https://sanderfrenken.github.io/`

but we need the path like:
`https://sanderfrenken.github.io/Universal-LPC-Spritesheet-Character-Generator`
.. to find the spritesheets to download

Also the txt version of credits i smuch nicer to read then the CSV version. using that now.
![image](https://user-images.githubusercontent.com/45912359/219113301-c3022716-b0e5-48cf-9d2e-8941247f1625.png)

