### PR TITLE
Add an option to re-order the generated sprite facings to SWEN

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!-- THIS FILE IS AUTO-GENERATED. PLEASE DONT ALTER IT MANUALLY -->
 <!DOCTYPE html>
-<html lang="en-us" xmlns="http://www.w3.org/1999/html">
+<html lang="en-us">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!-- THIS FILE IS AUTO-GENERATED. PLEASE DONT ALTER IT MANUALLY -->
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en-us" xmlns="http://www.w3.org/1999/html">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
@@ -27,6 +27,17 @@
 			<div>
 				<label class="control-label">Import/Export:</label>
 				<button type="button" class="exportToClipboard">Export to Clipboard (JSON)</button>
+			</div>
+			<div>
+				<label class="control-label">Facing Order:</label>
+				<label>
+					<input type="radio" id="nwse" name="facing_order" value="nwse" checked />
+					NWSE (default)
+				</label>
+				<label>
+					<input type="radio" id="swen" name="facing_order" value="swen" />
+					SWEN (experimental)
+				</label>
 			</div>
 			<div>
 				<label class="control-label">Edit:</label>

--- a/source_index.html
+++ b/source_index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-us" xmlns="http://www.w3.org/1999/html">
+<html lang="en-us">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">

--- a/source_index.html
+++ b/source_index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en-us" xmlns="http://www.w3.org/1999/html">
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
@@ -26,6 +26,17 @@
 			<div>
 				<label class="control-label">Import/Export:</label>
 				<button type="button" class="exportToClipboard">Export to Clipboard (JSON)</button>
+			</div>
+			<div>
+				<label class="control-label">Facing Order:</label>
+				<label>
+					<input type="radio" id="nwse" name="facing_order" value="nwse" checked />
+					NWSE (default)
+				</label>
+				<label>
+					<input type="radio" id="swen" name="facing_order" value="swen" />
+					SWEN (experimental)
+				</label>
 			</div>
 			<div>
 				<label class="control-label">Edit:</label>


### PR DESCRIPTION
Initial draft for the ability to reorder the generated sprite rows in the sheet - let me know if you have any specific feedback or concerns with this, or if there's any specific wording or spot on the page you want it. I've tested the basics so far - click through a few different body types and parts, download the resulting PNG, click to zoom, checked that NWSE still seems to work, verified that animations still show in SWEN mode.
![image](https://github.com/sanderfrenken/Universal-LPC-Spritesheet-Character-Generator/assets/5914284/f8d9412f-a511-4ff8-9f68-d9a2fbf53bad)
![image](https://github.com/sanderfrenken/Universal-LPC-Spritesheet-Character-Generator/assets/5914284/e7d10489-ba2e-4fda-9374-35198f3da771)
