### PR TITLE
Add ability to skip the first frame in a preview for a custom animation

### DIFF
--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -246,6 +246,9 @@ $(document).ready(function() {
       animRowNum = selectedCustomAnimation.frames.length;
       animRowStart = 0;
       for (var i = 0; i < selectedCustomAnimation.frames[0].length; ++i) {
+        if (selectedCustomAnimation.skipFirstFrameInPreview && i === 0  ) {
+          continue;
+        }
         animationItems.push(i);
       }
       return


### PR DESCRIPTION
For example could be used like this

```
  walk_128: {
    frameSize: 128,
    skipFirstFrameInPreview: true,
    frames: [
      ["walk-n,1", "walk-n,2", "walk-n,3", "walk-n,4", "walk-n,5", "walk-n,6", "walk-n,7", "walk-n,8"],
      ["walk-w,1", "walk-w,2", "walk-w,3", "walk-w,4", "walk-w,5", "walk-w,6", "walk-w,7", "walk-w,8"],
      ["walk-s,1", "walk-s,2", "walk-s,3", "walk-s,4", "walk-s,5", "walk-s,6", "walk-s,7", "walk-s,8"],
      ["walk-e,1", "walk-e,2", "walk-e,3", "walk-e,4", "walk-e,5", "walk-e,6", "walk-e,7", "walk-e,8"]
    ]
  },
```