### PR TITLE
Improved the Way Credits Work To Be Able to Support Directories Instead of Requiring Every Individual Image

### DIFF
--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -307,7 +307,7 @@ $(document).ready(function() {
       let prospectFile = '';
       for (let creditEntry of parsedCredits) {
         var creditPath = creditEntry.substring(0, creditEntry.indexOf(','));
-        if (fileName.startsWith(creditPath) && (creditPath.length > prospectName.length)) {
+        if (fileName.startsWith(creditPath) && (creditPath.length > prospectPath.length)) {
           prospect = creditEntry;
           prospectPath = creditPath;
           prospectFile = fileName;

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -302,8 +302,9 @@ $(document).ready(function() {
 
   function getCreditFor(fileName) {
     if (fileName !== "") {
-      var prospect = '';
-      var prospectName = '';
+      let prospect = '';
+      let prospectPath = '';
+      let prospectFile = '';
       for (let creditEntry of parsedCredits) {
         var creditPath = creditEntry.substring(0, creditEntry.indexOf(','));
         if (fileName.startsWith(creditPath) && (creditPath.length > prospectName.length)) {

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -302,12 +302,14 @@ $(document).ready(function() {
 
   function getCreditFor(fileName) {
     if (fileName !== "") {
-      let prospect = '';
+      var prospect = '';
+      var prospectName = '';
       for (let creditEntry of parsedCredits) {
         var creditPath = creditEntry.substring(0, creditEntry.indexOf(','));
-        if (fileName.startsWith(creditPath) && fileName.length > prospect.length) {
+        if (fileName.startsWith(creditPath) && (creditPath.length > prospectName.length)) {
           prospect = creditEntry;
-          console.log(creditEntry.replace(creditPath + ',', fileName + ','));
+          prospectPath = creditPath;
+          prospectFile = fileName;
         }
         if (creditEntry.startsWith(fileName)) {
           return creditEntry;
@@ -316,7 +318,7 @@ $(document).ready(function() {
 
       // Found closest match!
       if (prospect !== '') {
-        return prospect;
+        return prospect.replace(prospectPath, prospectFile);
       }
     }
   }

--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -302,11 +302,22 @@ $(document).ready(function() {
 
   function getCreditFor(fileName) {
     if (fileName !== "") {
+      let prospect = '';
       for (let creditEntry of parsedCredits) {
+        var creditPath = creditEntry.substring(0, creditEntry.indexOf(','));
+        if (fileName.startsWith(creditPath) && fileName.length > prospect.length) {
+          prospect = creditEntry;
+          console.log(creditEntry.replace(creditPath + ',', fileName + ','));
+        }
         if (creditEntry.startsWith(fileName)) {
           return creditEntry;
         }
       };
+
+      // Found closest match!
+      if (prospect !== '') {
+        return prospect;
+      }
     }
   }
 


### PR DESCRIPTION
From this issue:
https://github.com/sanderfrenken/Universal-LPC-Spritesheet-Character-Generator/issues/108

I added some code to improve the way credits work. It checks for the path first and grabs that. If it finds a closer match it grabs that instead, up to the point where it gets an exact match. If an exact match is found, all the "prospective" credits are ignored.

This allows us to simply set a path, like how I have on my latest set of updates:
`hair/extensions/xlong_bangl,,David Conway Jr. (JaidynReiman),"OGA-BY 3.0+, CC-BY 3.0+, GPL 3.0",https://opengameart.org/content/lpc-relm-hairstyle-pieces-xlong-ponytail-bangs-and-braids-headband,,,,,,,,,,,,,,,OK
hair/extensions/xlong_bangr,,David Conway Jr. (JaidynReiman),"OGA-BY 3.0+, CC-BY 3.0+, GPL 3.0",https://opengameart.org/content/lpc-relm-hairstyle-pieces-xlong-ponytail-bangs-and-braids-headband,,,,,,,,,,,,,,,OK
hair/extensions/xlong_braidl,,David Conway Jr. (JaidynReiman),"OGA-BY 3.0+, CC-BY 3.0+, GPL 3.0",https://opengameart.org/content/lpc-relm-hairstyle-pieces-xlong-ponytail-bangs-and-braids-headband,,,,,,,,,,,,,,,OK
hair/extensions/xlong_braidr,,David Conway Jr. (JaidynReiman),"OGA-BY 3.0+, CC-BY 3.0+, GPL 3.0",https://opengameart.org/content/lpc-relm-hairstyle-pieces-xlong-ponytail-bangs-and-braids-headband,,,,,,,,,,,,,,,OK`


But once you add the credits in, it still includes the full file path:
![credits-fix-preview](https://github.com/sanderfrenken/Universal-LPC-Spritesheet-Character-Generator/assets/3292008/b7fb90c8-25c2-4a53-bf44-a4e13d4da940)


Feel free to test out various methods and see if this works to your liking.


This will also make it easier if you eventually want to implement this feature:
https://github.com/sanderfrenken/Universal-LPC-Spritesheet-Character-Generator/issues/88