### PR TITLE
* HOTFIX: Resolved Bug Where Blank Licenses could Show Up

### DIFF
--- a/sources/chargen.js
+++ b/sources/chargen.js
@@ -307,7 +307,8 @@ $(document).ready(function() {
       let prospectFile = '';
       for (let creditEntry of parsedCredits) {
         var creditPath = creditEntry.substring(0, creditEntry.indexOf(','));
-        if (fileName.startsWith(creditPath) && (creditPath.length > prospectPath.length)) {
+        if (fileName.startsWith(creditPath) && (creditPath.length > prospectPath.length)
+            && !creditEntry.startsWith(creditPath + ',,,,')) {
           prospect = creditEntry;
           prospectPath = creditPath;
           prospectFile = fileName;


### PR DESCRIPTION
Resolved an issue where something like this:
```
kimono,,,,,,,,,,,,,,,,,,,
```

Could be picked up, and at the end no error was shown saying "no licensing information exists". It would just show up completely blank like this:
```
kimono/tight/universal/female/black.png: by . License(s): . 
```

If any details exist at that point, however, it will still show the above even if there's no license, so perhaps that should be addressed separately. This at least fixes it so it can't grab completely blank entries that only exist as spacers, though.